### PR TITLE
base class for error with custom model (GDEV-1021)

### DIFF
--- a/httpyexpect/__init__.py
+++ b/httpyexpect/__init__.py
@@ -15,4 +15,4 @@
 
 """An opinionated way to translate server side HTTP errors to the client side."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/httpyexpect/client/translator.py
+++ b/httpyexpect/client/translator.py
@@ -23,7 +23,7 @@ import requests
 
 from httpyexpect.client.exceptions import UnstructuredError
 from httpyexpect.client.mapping import ExceptionMapping
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 from httpyexpect.validation import ValidationError, assert_error_code
 
 
@@ -46,11 +46,11 @@ class ResponseTranslator:
         self._response = response
 
     @staticmethod
-    def _get_validated_exception_body(response: requests.Response) -> HTTPExceptionBody:
+    def _get_validated_exception_body(response: requests.Response) -> HttpExceptionBody:
         """Validates the response body against the HttpyExceptionBody model"""
         body = response.json()
         try:
-            return HTTPExceptionBody(**body)
+            return HttpExceptionBody(**body)
         except pydantic.ValidationError as error:
             raise UnstructuredError(
                 status_code=response.status_code, body=body

--- a/httpyexpect/models.py
+++ b/httpyexpect/models.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Extra, Field, constr
 EXCEPTION_ID_PATTERN = r"^[a-z][a-zA-Z0-9]{2,39}$"
 
 
-class HTTPExceptionBody(BaseModel):
+class HttpExceptionBody(BaseModel):
     """
     An opinionated base schema/model for the response body shipped with HTTP exception
     (on 4xx or 5xx status codes).

--- a/httpyexpect/models.py
+++ b/httpyexpect/models.py
@@ -24,8 +24,8 @@ EXCEPTION_ID_PATTERN = r"^[a-z][a-zA-Z0-9]{2,39}$"
 
 class HTTPExceptionBody(BaseModel):
     """
-    An opinionated schema for the response body shipped with HTTP exception (on 4xx
-    or 5xx status codes).
+    An opinionated base schema/model for the response body shipped with HTTP exception
+    (on 4xx or 5xx status codes).
     """
 
     class Config:

--- a/httpyexpect/server/__init__.py
+++ b/httpyexpect/server/__init__.py
@@ -19,4 +19,7 @@ server side.
 """
 
 # shortcuts:
-from httpyexpect.server.exceptions import HTTPException  # noqa: F401
+from httpyexpect.server.exceptions import (  # noqa: F401
+    HttpCustomExceptionBase,
+    HttpException,
+)

--- a/httpyexpect/server/exceptions.py
+++ b/httpyexpect/server/exceptions.py
@@ -22,7 +22,7 @@ from typing import Literal
 import pydantic
 
 from httpyexpect.base_exception import HttpyExpectError
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 from httpyexpect.validation import ValidationError, assert_error_code
 
 
@@ -60,7 +60,7 @@ class HttpException(HttpyExpectError):
 
         # prepare a body that is validated against the httpyexpect schema:
         try:
-            self.body = HTTPExceptionBody(
+            self.body = HttpExceptionBody(
                 exceptionId=exception_id, description=description, data=data
             )
         except pydantic.ValidationError as error:
@@ -135,7 +135,7 @@ class HttpCustomExceptionBase(ABC, HttpException):
         data_model.__name__ = data_model_name
         data_model.Config.title = data_model_name  # type: ignore
 
-        class CustomBodyModel(HTTPExceptionBody):
+        class CustomBodyModel(HttpExceptionBody):
             """A custom exception body model."""
 
             exceptionId: Literal[cls.exception_id]  # type: ignore

--- a/httpyexpect/server/exceptions.py
+++ b/httpyexpect/server/exceptions.py
@@ -16,6 +16,9 @@
 
 """Exception Base models used across all servers."""
 
+from abc import ABC
+from typing import Literal
+
 import pydantic
 
 from httpyexpect.base_exception import HttpyExpectError
@@ -23,7 +26,7 @@ from httpyexpect.models import HTTPExceptionBody
 from httpyexpect.validation import ValidationError, assert_error_code
 
 
-class HTTPException(HttpyExpectError):
+class HttpException(HttpyExpectError):
     """A generic exception model that can be translated into an HTTP response according
     to the httpyexpect exception schema.
     """
@@ -61,6 +64,89 @@ class HTTPException(HttpyExpectError):
                 exceptionId=exception_id, description=description, data=data
             )
         except pydantic.ValidationError as error:
-            raise ValidationError from error
+            raise ValidationError(
+                "Validation against basic HTTP exception body model failed."
+            ) from error
 
         super().__init__(description)
+
+
+class HttpCustomExceptionBase(ABC, HttpException):
+    """A base class for creating HTTP exceptions with custom response body models.
+
+    Usage:
+        - subclass this abstract class
+        - define the exception_id attribute
+        - optionally, overwrite the DataModel sub-class
+    """
+
+    exception_id: str
+
+    class DataModel(pydantic.BaseModel):
+        """An empty model used as default for describing exception data.
+        Please overwrite this to define your own data model.
+        """
+
+        class Config:
+            """Model Config"""
+
+            extra = pydantic.Extra.allow
+
+    def __init__(self, *, status_code: int, description: str, data: dict):
+        """Initialize the error with the required metadata.
+
+        Args:
+            status_code:
+                The response code of the HTTP response to send.
+            description:
+                A human readable message to the client explaining the cause of the
+                exception.
+            data:
+                An object containing further details on the exception cause in a machine
+                readable way.  All exceptions with the same exceptionId should use the
+                same set of properties here. This object may be empty (in case no data
+                is required)"
+        """
+
+        # validate the data against the custom model:
+        try:
+            self.DataModel(**data)
+        except pydantic.ValidationError as error:
+            raise ValidationError(
+                "Validation of data against custom model failed."
+            ) from error
+
+        super().__init__(
+            status_code=status_code,
+            exception_id=self.exception_id,
+            description=description,
+            data=data,
+        )
+
+    @classmethod
+    def get_body_model(cls):
+        """Creates and returns a custom pydantic model describing the exception body."""
+
+        body_model_name = cls.__name__
+
+        # derive and set the name of the exception data model:
+        data_model_name = f"{body_model_name}Data"
+        data_model = cls.DataModel
+        data_model.__name__ = data_model_name
+        data_model.Config.title = data_model_name  # type: ignore
+
+        class CustomBodyModel(HTTPExceptionBody):
+            """A custom exception body model."""
+
+            exceptionId: Literal[cls.exception_id]  # type: ignore
+            data: data_model  # type: ignore
+
+            class Config:
+                """Configure Model."""
+
+                extra = pydantic.Extra.forbid
+                titel = body_model_name
+
+        CustomBodyModel.__name__ = data_model_name
+
+        return CustomBodyModel

--- a/httpyexpect/server/handlers/fastapi_.py
+++ b/httpyexpect/server/handlers/fastapi_.py
@@ -21,7 +21,7 @@ Handeling exceptions in FastAPI. FastAPI has to be installed.
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from httpyexpect.server.exceptions import HTTPException
+from httpyexpect.server.exceptions import HttpException
 
 
 def configure_exception_handler(app: FastAPI) -> None:
@@ -31,11 +31,11 @@ def configure_exception_handler(app: FastAPI) -> None:
         app: The FastAPI to attach the exception handler to.
     """
 
-    @app.exception_handler(HTTPException)
+    @app.exception_handler(HttpException)
     def exception_handler(
         request: Request,  # pylint: disable=unused-argument
         # (The above is required by the corresponding FastAPI interface but not used here)
-        exc: HTTPException,
+        exc: HttpException,
     ) -> JSONResponse:
         """A custom exception handler that translates httypexpect's HTTPExceptions
         into a FastAPI JSONResponse."""

--- a/httpyexpect/server/handlers/fastapi_.py
+++ b/httpyexpect/server/handlers/fastapi_.py
@@ -25,7 +25,7 @@ from httpyexpect.server.exceptions import HttpException
 
 
 def configure_exception_handler(app: FastAPI) -> None:
-    """Configure an FastAPI app to handle httypexpect's HTTPExceptions.
+    """Configure an FastAPI app to handle httypexpect's HttpExceptions.
 
     Args:
         app: The FastAPI to attach the exception handler to.
@@ -37,6 +37,6 @@ def configure_exception_handler(app: FastAPI) -> None:
         # (The above is required by the corresponding FastAPI interface but not used here)
         exc: HttpException,
     ) -> JSONResponse:
-        """A custom exception handler that translates httypexpect's HTTPExceptions
+        """A custom exception handler that translates httypexpect's HttpExceptions
         into a FastAPI JSONResponse."""
         return JSONResponse(status_code=exc.status_code, content=exc.body.dict())

--- a/json_schemas/http_exception.json
+++ b/json_schemas/http_exception.json
@@ -1,6 +1,6 @@
 {
   "additionalProperties": false,
-  "description": "An opinionated schema for the response body shipped with HTTP exception (on 4xx\nor 5xx status codes).",
+  "description": "An opinionated base schema/model for the response body shipped with HTTP exception\n(on 4xx or 5xx status codes).",
   "properties": {
     "data": {
       "description": "An object containing further details on the exception cause in a machine readable way. All exceptions with the same exceptionId should use the same set of properties here. This object may be empty (in case no data is required)",

--- a/json_schemas/http_exception.json
+++ b/json_schemas/http_exception.json
@@ -24,6 +24,6 @@
     "description",
     "exceptionId"
   ],
-  "title": "HTTPExceptionBody",
+  "title": "HttpExceptionBody",
   "type": "object"
 }

--- a/scripts/update_http_exception_schema.py
+++ b/scripts/update_http_exception_schema.py
@@ -29,7 +29,7 @@ from typing import Mapping, Sequence
 import typer
 from pydantic import BaseModel
 
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 
 REPO_ROOT_DIR = Path(__file__).parent.parent.resolve()
 JSON_SCHEMA_PATH = REPO_ROOT_DIR / "json_schemas" / "http_exception.json"
@@ -135,13 +135,13 @@ def main(
 
     if check:
         try:
-            check_json_schema(schema_path=JSON_SCHEMA_PATH, model=HTTPExceptionBody)
+            check_json_schema(schema_path=JSON_SCHEMA_PATH, model=HttpExceptionBody)
         except ValidationError as error:
             typer.secho(str(error), fg=typer.colors.RED)
             sys.exit(1)
         typer.secho("The JSON schema is up to date.", fg=typer.colors.GREEN)
     else:
-        updates_json_schema(schema_path=JSON_SCHEMA_PATH, model=HTTPExceptionBody)
+        updates_json_schema(schema_path=JSON_SCHEMA_PATH, model=HttpExceptionBody)
         typer.secho("Successfully updated the JSON schema.", fg=typer.colors.GREEN)
 
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -21,7 +21,7 @@ from unittest.mock import Mock
 import pytest
 
 from httpyexpect.client import ExceptionMapping, ResponseTranslator
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 
 
 class ExceptionA(RuntimeError):
@@ -41,21 +41,21 @@ class ExceptionC(RuntimeError):
     [
         (
             400,
-            HTTPExceptionBody(
+            HttpExceptionBody(
                 exceptionId="testA", description="test", data={"test": "test"}
             ),
             ExceptionA,
         ),
         (
             400,
-            HTTPExceptionBody(
+            HttpExceptionBody(
                 exceptionId="testB", description="test", data={"test": "test"}
             ),
             ExceptionB,
         ),
         (
             500,
-            HTTPExceptionBody(
+            HttpExceptionBody(
                 exceptionId="testC", description="test", data={"test": "test"}
             ),
             ExceptionC,
@@ -63,7 +63,7 @@ class ExceptionC(RuntimeError):
     ],
 )
 def test_typical_client_usage(
-    status_code: int, body: HTTPExceptionBody, expected_exception: type[Exception]
+    status_code: int, body: HttpExceptionBody, expected_exception: type[Exception]
 ):
     """Test the typical way how the client may use the `ResponseTranslator` together
     with the `ExceptionMapping` classes."""

--- a/tests/integration/test_fastapi.py
+++ b/tests/integration/test_fastapi.py
@@ -19,7 +19,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from httpyexpect.server import HTTPException
+from httpyexpect.server import HttpException
 from httpyexpect.server.handlers.fastapi_ import configure_exception_handler
 
 
@@ -40,7 +40,7 @@ def test_configure_exception_handler():
     @app.get("/test")
     def test_route():
         """A test route function raising an httpyexpect error"""
-        raise HTTPException(
+        raise HttpException(
             status_code=status_code,
             exception_id=exception_id,
             description=description,

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -21,7 +21,7 @@ from contextlib import nullcontext
 import pytest
 from pydantic import ValidationError
 
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 
 
 @pytest.mark.parametrize(
@@ -51,4 +51,4 @@ def test_http_exception_body(
     """Test validation logic of the HTTPExceptionBody model."""
 
     with nullcontext() if is_valid else pytest.raises(ValidationError):  # type: ignore
-        HTTPExceptionBody(exceptionId=exceptionId, description=description, data=data)
+        HttpExceptionBody(exceptionId=exceptionId, description=description, data=data)

--- a/tests/unit/test_server_exceptions.py
+++ b/tests/unit/test_server_exceptions.py
@@ -18,7 +18,7 @@
 import pydantic
 import pytest
 
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 from httpyexpect.server import HttpCustomExceptionBase, HttpException
 from httpyexpect.validation import ValidationError
 
@@ -36,7 +36,7 @@ def test_http_exception():
 
     # example params for an http exception
     status_code = 400
-    body = HTTPExceptionBody(
+    body = HttpExceptionBody(
         exceptionId="testException",
         description="This is a test exception.",
         data={"test": "test"},
@@ -91,7 +91,7 @@ def test_http_custom_exception():
 
     # example params for an http exception
     status_code = 400
-    body = HTTPExceptionBody(
+    body = HttpExceptionBody(
         exceptionId=MyCustomHttpException.exception_id,
         description="This is a test exception.",
         data={"some_param": "data", "another_param": 123},

--- a/tests/unit/test_server_exceptions.py
+++ b/tests/unit/test_server_exceptions.py
@@ -15,14 +15,23 @@
 
 """Test the base exception for servers."""
 
+import pydantic
 import pytest
 
 from httpyexpect.models import HTTPExceptionBody
-from httpyexpect.server import HTTPException
+from httpyexpect.server import HttpCustomExceptionBase, HttpException
 from httpyexpect.validation import ValidationError
 
 
-def test_httpexception():
+class MyCustomHttpException(HttpCustomExceptionBase):
+    exception_id = "myHttpException"
+
+    class DataModel(pydantic.BaseModel):
+        some_param: str
+        another_param: int
+
+
+def test_http_exception():
     """Tests the interface and behavior of HTTPException instances."""
 
     # example params for an http exception
@@ -34,7 +43,7 @@ def test_httpexception():
     )
 
     # create an exception:
-    exception = HTTPException(
+    exception = HttpException(
         status_code=status_code,
         exception_id=body.exceptionId,
         description=body.description,
@@ -62,15 +71,92 @@ def test_httpexception():
         (400, "myValidExceptionID", "A valid description", 123),
     ],
 )
-def test_httpexception_invalid_params(
+def test_http_exception_invalid_params(
     status_code: object, exception_id: object, description: object, data: object
 ):
     """Tests creating an HTTPException with invalid params."""
 
     with pytest.raises(ValidationError):
-        HTTPException(
+        HttpException(
             status_code=status_code,  # type: ignore
             exception_id=exception_id,  # type: ignore
+            description=description,  # type: ignore
+            data=data,  # type: ignore
+        )
+
+
+def test_http_custom_exception():
+    """Tests the interface and behavior of instances of subclasses of the
+    HttpCustomExceptionBase."""
+
+    # example params for an http exception
+    status_code = 400
+    body = HTTPExceptionBody(
+        exceptionId=MyCustomHttpException.exception_id,
+        description="This is a test exception.",
+        data={"some_param": "data", "another_param": 123},
+    )
+
+    # create an exception:
+    exception = MyCustomHttpException(
+        status_code=status_code,
+        description=body.description,
+        data=body.data,
+    )
+
+    # check public attributes:
+    assert exception.body == body
+    assert exception.status_code == status_code
+
+    # check error message:
+    assert str(exception) == body.description
+
+
+def test_http_custom_exception_body():
+    """Tests the interface and behavior of HttpCustomExceptionBase instances."""
+
+    body_model = MyCustomHttpException.get_body_model()
+    assert issubclass(body_model, pydantic.BaseModel)
+
+    # evaluate the schema:
+    body_schema = body_model.schema()
+    assert set(body_schema["properties"].keys()) == {
+        "data",
+        "description",
+        "exceptionId",
+    }
+
+    exception_id_schema = body_schema["properties"]["exceptionId"]
+    assert exception_id_schema["type"] == "string"
+    assert "enum" in exception_id_schema
+    assert exception_id_schema["enum"][0] == MyCustomHttpException.exception_id
+
+    assert "$ref" in body_schema["properties"]["data"]
+    data_definition_name = body_schema["properties"]["data"]["$ref"].split("/")[-1]
+    data_definition = body_schema["definitions"][data_definition_name]
+    assert data_definition["type"] == "object"
+    assert set(data_definition["properties"].keys()) == {"some_param", "another_param"}
+
+
+@pytest.mark.parametrize(
+    "status_code, description, data",
+    [
+        # invalid status codes:
+        (200, "A valid description", {"some_param": "data", "another_param": 123}),
+        (600, "A valid description", {"some_param": "data", "another_param": 123}),
+        # invalid data:
+        (400, "A valid description", {}),
+        (400, "A valid description", {"some_random_param": "data"}),
+    ],
+)
+def test_http_custom_exception_invalid_params(
+    status_code: object, description: object, data: object
+):
+    """Tests the interface and behavior of HttpCustomExceptionBase instances."""
+
+    with pytest.raises(ValidationError):
+        MyCustomHttpException(
+            status_code=status_code,  # type: ignore
             description=description,  # type: ignore
             data=data,  # type: ignore
         )

--- a/tests/unit/test_translator.py
+++ b/tests/unit/test_translator.py
@@ -24,7 +24,7 @@ import pytest
 from httpyexpect.client.exceptions import UnstructuredError
 from httpyexpect.client.mapping import EXCEPTION_FACTORY_PARAMS, FactoryKit
 from httpyexpect.client.translator import ResponseTranslator
-from httpyexpect.models import HTTPExceptionBody
+from httpyexpect.models import HttpExceptionBody
 
 
 class TestException(RuntimeError):
@@ -96,7 +96,7 @@ def test_response_translator_error(case: Case):
     )
 
     # create http response mock:
-    body = HTTPExceptionBody(
+    body = HttpExceptionBody(
         exceptionId=case.exception_id, description=case.description, data=case.data
     )
     response = Mock()


### PR DESCRIPTION
Added a base class that upon subclassing can be configured
with a custom data model and can be used to
generate custom body model.
These custom models are useful for instance when
constructing an openapi doc with FastAPI.

Bump version to 0.2.0.