### PR TITLE
fix titles in FastAPI_generated OpenAPI (GDEV-1460)

### DIFF
--- a/httpyexpect/__init__.py
+++ b/httpyexpect/__init__.py
@@ -15,4 +15,4 @@
 
 """An opinionated way to translate server side HTTP errors to the client side."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/httpyexpect/server/exceptions.py
+++ b/httpyexpect/server/exceptions.py
@@ -145,7 +145,6 @@ class HttpCustomExceptionBase(ABC, HttpException):
 
         # customize the class name by subclassing:
         named_data_model = type(data_model_name, (cls.DataModel,), {})
-        named_data_model.Config.title = data_model_name  # type: ignore
 
         class CustomBodyModel(HttpExceptionBody):
             """A custom exception body model."""
@@ -157,7 +156,6 @@ class HttpCustomExceptionBase(ABC, HttpException):
                 """Configure Model."""
 
                 extra = pydantic.Extra.forbid
-                title = body_model_name
 
         # customize the class name by subclassing:
         named_custom_model = type(body_model_name, (CustomBodyModel,), {})


### PR DESCRIPTION
```
When custom exceptions based on HttpCustomExceptionBase where used together with FastAPI to generate an OpenAPI documentation, the titles were wrong.

The titles were attempted to be set explicitly in the base class. That worked fine for the pydantic-based schema validation, however caused problems wit the OpenAPI generator of FastAPI,
which automatically sets the title based
on the class name.
Simply removing the explicit title definition thus resolved the problem.

Bumps version to 0.2.4.

Co-authored-by: Moritz Hahn <75744178+MoritzHahn1337@users.noreply.github.com>
Co-authored-by: Thomas Zajac <thomas-jakob.zajac@uni-tuebingen.de>
```