### PR TITLE
Remove dependency from requests library

### DIFF
--- a/.static_files
+++ b/.static_files
@@ -15,6 +15,7 @@
 scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
+scripts/__init__.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/httpyexpect/client/__init__.py
+++ b/httpyexpect/client/__init__.py
@@ -20,5 +20,6 @@ exceptions.
 
 
 # shortcuts:
+from httpyexpect.client.custom_types import Response  # noqa: F401
 from httpyexpect.client.mapping import ExceptionMapping  # noqa: F401
 from httpyexpect.client.translator import ResponseTranslator  # noqa: F401

--- a/httpyexpect/client/custom_types.py
+++ b/httpyexpect/client/custom_types.py
@@ -16,10 +16,21 @@
 
 """Custom types and type aliases."""
 
-from typing import Callable, Literal, Mapping
+from typing import Any, Callable, Literal, Mapping, Protocol
 
 ExceptionFactoryParam = Literal["status_code", "exception_id", "description", "data"]
 StatusCode = int
 ExceptionId = str
 ExceptionFactory = Callable[..., Exception]
 ExceptionMappingSpec = Mapping[StatusCode, object]
+
+
+class Response(Protocol):
+    """Any Response that is compatible with httpx and requests."""
+
+    status_code: int
+    """The status code or the Response"""
+
+    def json(self, **kwargs: Any) -> Any:
+        """JSON representation of the Response."""
+        ...

--- a/httpyexpect/client/custom_types.py
+++ b/httpyexpect/client/custom_types.py
@@ -29,8 +29,8 @@ class Response(Protocol):
     """Any Response that is compatible with httpx and requests."""
 
     status_code: int
-    """The status code or the Response"""
+    """Status code of the Response"""
 
     def json(self, **kwargs: Any) -> Any:
-        """JSON representation of the Response."""
+        """JSON representation of the Response"""
         ...

--- a/httpyexpect/client/translator.py
+++ b/httpyexpect/client/translator.py
@@ -16,25 +16,15 @@
 
 """Logic to translate responses to HTTP calls to python exceptions."""
 
-from typing import Any, Optional, Protocol
+from typing import Optional
 
 import pydantic
 
+from httpyexpect.client.custom_types import Response
 from httpyexpect.client.exceptions import UnstructuredError
 from httpyexpect.client.mapping import ExceptionMapping
 from httpyexpect.models import HttpExceptionBody
 from httpyexpect.validation import ValidationError, assert_error_code
-
-
-class Response(Protocol):
-    """Any Response that is compatible with httpx and requests."""
-
-    status_code: int
-    """The status code or the Response"""
-
-    def json(self, **kwargs: Any) -> Any:
-        """JSON representation of the Response."""
-        ...
 
 
 class ResponseTranslator:

--- a/httpyexpect/client/translator.py
+++ b/httpyexpect/client/translator.py
@@ -18,8 +18,8 @@
 
 from typing import Optional
 
+import httpx
 import pydantic
-import requests
 
 from httpyexpect.client.exceptions import UnstructuredError
 from httpyexpect.client.mapping import ExceptionMapping
@@ -31,12 +31,12 @@ class ResponseTranslator:
     """Translates a specific response to an HTTP call using an ExceptionMapping to
     python exceptions (in case of an error code)."""
 
-    def __init__(self, response: requests.Response, *, exception_map: ExceptionMapping):
+    def __init__(self, response: httpx.Response, *, exception_map: ExceptionMapping):
         """Initialize the translator.
 
         Args:
             response:
-                A response to an HTTP call performed with the `requests` library.
+                A response to an HTTP call performed with the `httpx` library.
             exception_map:
                 An exception mapping specifying translations between status codes plus
                 exception IDs and python exceptions.
@@ -46,7 +46,7 @@ class ResponseTranslator:
         self._response = response
 
     @staticmethod
-    def _get_validated_exception_body(response: requests.Response) -> HttpExceptionBody:
+    def _get_validated_exception_body(response: httpx.Response) -> HttpExceptionBody:
         """Validates the response body against the HttpyExceptionBody model"""
         body = response.json()
         try:
@@ -58,7 +58,7 @@ class ResponseTranslator:
 
     @classmethod
     def _construct_exception(
-        cls, response: requests.Response, exception_map: ExceptionMapping
+        cls, response: httpx.Response, exception_map: ExceptionMapping
     ) -> Exception:
         """Construct a python exception from a response."""
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-"""An opinionated way to translate server side HTTP errors to the client side."""
-
-__version__ = "0.2.7"
+"""Scripts and utils used during development or in CI pipelines."""

--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -33,7 +33,7 @@ from pathlib import Path
 try:
     from script_utils.cli import echo_failure, echo_success, run
 except ImportError:
-    echo_failure = echo_success = print  # type: ignore
+    echo_failure = echo_success = print
 
     def run(main_fn):
         """Run main function without cli tools (typer)."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,9 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-install_requires =
 python_requires = >= 3.9
+install_requires =
+    httpx>=0.23.3
 
 [options.package_data]
 * = *.yaml, *.json, *.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ include_package_data = True
 packages = find:
 python_requires = >= 3.9
 install_requires =
-    httpx>=0.23.3
 
 [options.package_data]
 * = *.yaml, *.json, *.html


### PR DESCRIPTION
The package imported requests though it was only used for type checking. Instead of requiring requests (or httpx), we use a protocol that is compatible with both of them.